### PR TITLE
props added to lifecycle group for Flow

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -94,6 +94,7 @@ module.exports = {
                     "state",
                     "contextTypes",
                     "childContextTypes",
+                    "props",
                     "propTypes",
                     "defaultProps",
                     "static-methods",


### PR DESCRIPTION
Will now allow `props` for Flow prop type checking to be put at the top of the component:
```
class MyComponent extends React.Component {
    props: {
        id: string,
        config: Object
    };

...
 ```